### PR TITLE
chore: Move from mocha to node:test

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,6 +1,0 @@
-{
-  "timeout": 50000,
-  "require": ["tsx", "source-map-support/register"],
-  "reporter": "Spec",
-  "extension": ".test.ts"
-}

--- a/packages/pinion/package.json
+++ b/packages/pinion/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "prepublish": "npm run compile",
     "compile": "shx rm -rf lib/ && tsc",
-    "test": "npm run compile && shx rm -rf test/tmp && mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts --exit"
+    "test": "npm run compile && shx rm -rf test/tmp && node --import tsx --test test/**.test.ts"
   },
   "directories": {
     "lib": "lib"
@@ -62,9 +62,7 @@
     "tsx": "^4.7.0"
   },
   "devDependencies": {
-    "@types/mocha": "^10.0.6",
     "@types/node": "^20.10.6",
-    "mocha": "^10.2.0",
     "shx": "^0.3.4",
     "typescript": "^5.3.3"
   },

--- a/packages/pinion/test/cli.test.ts
+++ b/packages/pinion/test/cli.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from 'node:test'
 import assert from 'assert'
 import { fileURLToPath } from 'url'
 import { dirname } from 'path'

--- a/packages/pinion/test/index.test.ts
+++ b/packages/pinion/test/index.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from 'node:test'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { readFile } from 'fs/promises'

--- a/packages/pinion/test/utils.test.ts
+++ b/packages/pinion/test/utils.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from 'node:test'
 import path from 'path'
 import assert from 'assert'
 import { merge, listAllFiles, loadModule, listFiles } from '../lib/utils.js'


### PR DESCRIPTION
It does the same thing, is faster and less dependencies that can potentially break.