### PR TITLE
fix: Ensure all module names are proper URLs

### DIFF
--- a/packages/pinion/src/core.ts
+++ b/packages/pinion/src/core.ts
@@ -162,7 +162,7 @@ export const getContext = <T extends PinionContext>(
 export const generator = async <T extends PinionContext>(initialContext: T) => initialContext
 
 export const runModule = async (file: string, ctx: PinionContext) => {
-  const { generate } = await loadModule(`file://${file}`)
+  const { generate } = await loadModule(file)
 
   return generate(ctx)
 }

--- a/packages/pinion/src/utils.ts
+++ b/packages/pinion/src/utils.ts
@@ -7,24 +7,26 @@ let tsModule: any
 const tsRegister = async (mod = 'tsx') => (tsModule = tsModule || import(mod))
 
 const extensionCheck = /(\.ts|\.js)$/
-const getFileName = (file: string) => {
-  if (extensionCheck.test(file)) {
-    return file
+const getFileUrl = (file: string) => {
+  let url = file
+
+  if (!extensionCheck.test(file)) {
+    if (existsSync(`${file}.js`)) {
+      url = `${file}.js`
+    } else if (existsSync(`${file}.ts`)) {
+      url = `${file}.ts`
+    }
   }
 
-  if (existsSync(`${file}.js`)) {
-    return `${file}.js`
-  }
-
-  if (existsSync(`${file}.ts`)) {
-    return `${file}.ts`
+  if (!url.startsWith('file://')) {
+    url = `file://${url}`
   }
 
   return file
 }
 
 export const loadModule = async (file: string) => {
-  const fileName = getFileName(file)
+  const fileName = getFileUrl(file)
 
   if (fileName.endsWith('.ts')) {
     await tsRegister()


### PR DESCRIPTION
This is a follow-up to #59 and ensures all file names are valid URLs.

Should close #60