### PR TITLE
fix: Support absolute file path for CLI

### DIFF
--- a/packages/pinion/src/cli.ts
+++ b/packages/pinion/src/cli.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander'
 import { fileURLToPath } from 'url'
 import { getContext } from './core.js'
 import { loadModule } from './utils.js'
+import { isAbsolute } from 'path';
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -29,8 +30,12 @@ export const cli = async (cmd: string[]) => {
   if (!generatorFile) {
     throw new Error('Please specify a generator file name')
   }
-
-  const moduleName = join(process.cwd(), generatorFile)
+  let moduleName:string
+  if(isAbsolute(generatorFile)){
+     moduleName = generatorFile
+  }else{
+     moduleName = join(process.cwd(), generatorFile)
+  }
 
   if (!existsSync(moduleName)) {
     throw new Error(`The generator file ${moduleName} does not exists`)

--- a/packages/pinion/src/cli.ts
+++ b/packages/pinion/src/cli.ts
@@ -30,12 +30,8 @@ export const cli = async (cmd: string[]) => {
   if (!generatorFile) {
     throw new Error('Please specify a generator file name')
   }
-  let moduleName:string
-  if(isAbsolute(generatorFile)){
-     moduleName = generatorFile
-  }else{
-     moduleName = join(process.cwd(), generatorFile)
-  }
+  
+  const moduleName = isAbsolute(generatorFile) ? generatorFile : join(process.cwd(), generatorFile)
 
   if (!existsSync(moduleName)) {
     throw new Error(`The generator file ${moduleName} does not exists`)


### PR DESCRIPTION
### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/crow/.github/contributing.md#pull-requests))

- [ ] Tell us about the problem your pull request is solving.
      when I execute `npx pinion   /Users/prozhou/playgroud/pinion-gen/generators/ts/gen.tpl.ts`, the comand will be `npx pinion   /Users/prozhou/playgroud/Users/prozhou/playgroud/pinion-gen/generators/ts/gen.tpl.ts` when cmd is ` /Users/prozhou/playgroud`.
- [ ] Are there any open issues that are related to this?
no
- [ ] Is this PR dependent on PRs in other repos?
no
If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: